### PR TITLE
Add absolute value implementation.

### DIFF
--- a/include/tack/float4.h
+++ b/include/tack/float4.h
@@ -210,6 +210,12 @@ inline float4 min(const float4& a, const float4& b)
     return _mm_min_ps(a, b);
 }
 
+inline float4 abs(const float4& a)
+{
+    static const float4 sign_mask(-0.f);
+    return _mm_andnot_ps(sign_mask, a);
+}
+
 template <uint8_t x, uint8_t y, uint8_t z, uint8_t w>
 inline float4 shuffle(const float4& a, const float4& b)
 {

--- a/testing/test_float4.cpp
+++ b/testing/test_float4.cpp
@@ -1,33 +1,27 @@
 #include "testing.h"
 #include <tack/float4.h>
+#include <array>
 
-struct test_float4_t : public test_t {
+struct test_float4_abs_t : public test_t {
 
-    test_float4_t()
-        : test_t("test_float4")
+    test_float4_abs_t()
+            : test_t("test_float4_abs")
     {
         register_test(this);
     }
 
-    void test1()
-    {
-        using namespace tack;
-
-        float4 a(0.1f);
-        float4 b(0.1f, 0.2f, 0.3f, 0.4f);
-        for (int i = 0; i < 10; ++i) {
-            a += b;
-        }
-        float4 c = b;
-    }
-
     virtual bool run() override
     {
-        test1();
+        using namespace tack;
+        const float4 a(-1, 2, -3, 4);
+        const float4 b = abs(a);
+        std::array<float, 4> out;
+        b.store(out.data());
+        pass_ &= out[0]==1.f && out[1]==2.f && out[2]==3.f && out[3]==4.f;
         return passed();
     }
 };
 
 namespace {
-test_float4_t test_instance;
+test_float4_abs_t test_1;
 } // namespace {}

--- a/testing/test_float4.cpp
+++ b/testing/test_float4.cpp
@@ -5,7 +5,7 @@
 struct test_float4_abs_t : public test_t {
 
     test_float4_abs_t()
-            : test_t("test_float4_abs")
+        : test_t("test_float4_abs")
     {
         register_test(this);
     }
@@ -17,7 +17,7 @@ struct test_float4_abs_t : public test_t {
         const float4 b = abs(a);
         std::array<float, 4> out;
         b.store(out.data());
-        pass_ &= out[0]==1.f && out[1]==2.f && out[2]==3.f && out[3]==4.f;
+        pass_ &= out[0] == 1.f && out[1] == 2.f && out[2] == 3.f && out[3] == 4.f;
         return passed();
     }
 };


### PR DESCRIPTION
This PR adds and absolute value implementation.  We create a vector with all of the floatingpoint sign bits set, and then use it to mask out the sign bits of the input vector, forcing every lane positive.
