### PR TITLE
Add float4 compare helper function

### DIFF
--- a/testing/test_float4.cpp
+++ b/testing/test_float4.cpp
@@ -9,7 +9,7 @@ TEST(float4, abs)
     const float4 b = abs(a);
     std::array<float, 4> out;
     b.store(out.data());
-    ASSERT(out[0] == 1.f && out[1] == 2.f && out[2] == 3.f && out[3] == 4.f);
+    ASSERT(equals(b, float4(1.f, 2.f, 3.f, 4.f)));
 }
 
 TEST(float4, equal)

--- a/testing/testing.cpp
+++ b/testing/testing.cpp
@@ -1,7 +1,10 @@
 #include <cstdio>
 #include <cassert>
 #include <vector>
+#include <array>
+#include <cmath>
 #include "testing.h"
+#include <tack/float4.h>
 
 namespace {
 std::vector<test_t*> s_tests;
@@ -10,6 +13,16 @@ std::vector<test_t*> s_tests;
 void register_test(test_t* test)
 {
     s_tests.push_back(test);
+}
+
+bool equals(const tack::float4 &a, const tack::float4 &b, float tolerance) {
+    std::array<float, 4> av, bv;
+    a.store(av.data());
+    b.store(bv.data());
+    bool pass = true;
+    for (size_t i=0; i<4; ++i)
+        pass &= (fabsf(bv[i]-av[i]) < tolerance);
+    return pass;
 }
 
 int main()

--- a/testing/testing.h
+++ b/testing/testing.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <string>
 #include <vector>
+#include <tack/float4.h>
 
 struct test_t {
 
@@ -59,6 +60,7 @@ protected:
 };
 
 void register_test(test_t* instance);
+bool equals(const tack::float4 &a, const tack::float4 &b, float tolerance=0.001f);
 
 #define TEST(GROUP, NAME)                           \
     namespace {                                     \


### PR DESCRIPTION
This PR should help simplify and improve readability for test cases where we try to match the entire state of a float4.
