### PR TITLE
Add string include needed for strlen()

### DIFF
--- a/testing/testing.h
+++ b/testing/testing.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <string>
 #include <vector>
+#include <cstring>
 #include <tack/float4.h>
 
 struct test_t {


### PR DESCRIPTION
Fix for the compiler error I got with gcc on master about strlen() not being defined.
